### PR TITLE
Update COMPRESS_ES6_COMPILER_CMD in readme to match the default in so…

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Default:
 
 ```py
 'export NODE_PATH="{paths}" && '
-'{browserify_bin} "{infile}" -o "{outfile}" --no-bundle-external --node '
+'{browserify_bin} "{infile}" -o "{outfile}" '
 '-t [ "{node_modules}/babelify" --presets="{node_modules}/babel-preset-es2015" ]'
 ```
 


### PR DESCRIPTION
…urce

Noticed that the paths specified in `NODE_PATH` weren't working as expected. Looked at the command for `COMPRESS_ES6_COMPILER_CMD` that I'd copied from the readme (edited to use `babel-preset-env`) and noticed that it differs from the default `ES6_COMPILER_CMD` specified in `apps.py`.

I assume that the default command was updated at some point, leaving the readme outdated. So this is just to update it to match the new command.

Thanks for the useful package!