### PR TITLE
Add `rel="stylesheet"` to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ COMPRESS_PRECOMPILERS = (
 {% load compress %}
 
 {% compress css %}
-  <link type="text/x-scss" href="{% static 'app/layout.scss' %}">
+  <link rel="stylesheet" type="text/x-scss" href="{% static 'app/layout.scss' %}">
 {% endcompress %}
 ```
 


### PR DESCRIPTION
Otherwise the entry would be ignored by django-compressor.
(Using Django Compressor v2.2 on Django v2.0b1)